### PR TITLE
Fix vt100 support call on non-Windows systems

### DIFF
--- a/src/AquaRelay.php
+++ b/src/AquaRelay.php
@@ -31,7 +31,9 @@ use function version_compare;
 require dirname(__DIR__) . '/vendor/autoload.php';
 
 if (Colors::supportsColors()){
-	@sapi_windows_vt100_support(STDOUT, true);
+	if (PHP_OS_FAMILY === "Windows" && function_exists('\sapi_windows_vt100_support')) {
+		@\sapi_windows_vt100_support(STDOUT, true);
+	}
 }
 
 function error(string $message) : void


### PR DESCRIPTION
# What's going on here?
As seen in `Colors::supportColors():`
<img width="662" height="134" alt="image" src="https://github.com/user-attachments/assets/da1dfcdb-194a-4777-8a4b-c642f9e3b3d1" />

**If PHP_OS_FAMILY is not Windows, it always returns true.**
Then, directly in AquaRelay.php:
```php
if (Colors::supportsColors()){
   @\sapi_windows_vt100_support(STDOUT, true);
}
```
was present. You get the idea :question: :p

# Changes
- Fixed vt100 support call on non-Windows systems.

# Results
<img width="883" height="112" alt="result" src="https://github.com/user-attachments/assets/69fcc425-abe6-4755-b2a8-3538cf2bc973" />
