### PR TITLE
Fix the ticks and add shutdown method

### DIFF
--- a/src/ProxyServer.php
+++ b/src/ProxyServer.php
@@ -34,7 +34,7 @@ use aquarelay\plugin\PluginManager;
 use aquarelay\task\TaskScheduler;
 use aquarelay\utils\Colors;
 use aquarelay\utils\MainLogger;
-use aquarelay\utils\ProxyUtils;
+use aquarelay\utils\Utils;
 use pocketmine\network\mcpe\protocol\ProtocolInfo;
 
 class ProxyServer {
@@ -275,11 +275,7 @@ class ProxyServer {
 
         $this->handleRestartThrottle();
         $this->logger->shutdown();
-        
-        // Ensure the process actually dies (force kill self)
-        // We use exit(0) to signal to the OS that this was a purposeful, clean shutdown.
-        @ProxyUtils::kill(ProxyUtils::pid()); 
-        exit(0);
+        @Utils::kill(Utils::pid()); 
     }
 
     /**

--- a/src/ProxyServer.php
+++ b/src/ProxyServer.php
@@ -27,12 +27,14 @@ use aquarelay\config\ProxyConfig;
 use aquarelay\network\compression\ZlibCompressor;
 use aquarelay\network\ProxyLoop;
 use aquarelay\network\raklib\RakLibInterface;
+use aquarelay\player\Player;
 use aquarelay\player\PlayerManager;
 use aquarelay\plugin\PluginLoader;
 use aquarelay\plugin\PluginManager;
 use aquarelay\task\TaskScheduler;
 use aquarelay\utils\Colors;
 use aquarelay\utils\MainLogger;
+use aquarelay\utils\ProxyUtils;
 use pocketmine\network\mcpe\protocol\ProtocolInfo;
 
 class ProxyServer {
@@ -47,6 +49,8 @@ class ProxyServer {
 	private PlayerManager $playerManager;
 	private PluginManager $pluginManager;
 	private TaskScheduler $taskScheduler;
+
+	private float $startProcessTime;
 
 	/**
 	 * Returns a server instance, can be nullable
@@ -172,7 +176,7 @@ class ProxyServer {
 		}
 
 		self::$instance = $this;
-		$startTime = microtime(true);
+		$this->startProcessTime = microtime(true);
 		$configFile = $this->dataPath . "config.yml";
 
 		if (!file_exists($configFile)) {
@@ -206,6 +210,8 @@ class ProxyServer {
 		$this->playerManager = new PlayerManager();
 		$this->taskScheduler = new TaskScheduler();
 
+		register_shutdown_function([$this, "shutdown"]);
+
 		$threshold = $this->getConfig()->getNetworkSettings()->getBatchThreshold();
 		$compressionThreshold = $threshold >= 0 ? $threshold : null;
 
@@ -233,10 +239,63 @@ class ProxyServer {
 
 		$this->interface->start();
 
-		$this->logger->info("Proxy started! (" . round(microtime(true) - $startTime, 3) ."s)");
+		$this->logger->info("Proxy started! (" . round(microtime(true) - $this->startProcessTime, 3) ."s)");
 		
 		$loop = new ProxyLoop($this);
 		$loop->run();
 	}
 
+	public function shutdown() : void
+    {
+        $shutdownStart = microtime(true);
+
+		foreach ($this->getOnlinePlayers() as $player) {
+			/** @var Player $player */
+			$player->disconnect("Proxy is shutting down");
+		}
+
+        foreach ($this->pluginManager->getPlugins() as $plugin) {
+            if ($plugin->isEnabled()) {
+                try {
+                    $this->pluginManager->disablePlugin($plugin);
+                } catch (\Throwable $e) {
+                    $this->logger->error("Failed to disable plugin " . $plugin->getName() . ": " . $e->getMessage());
+                    $this->logger->logException($e);
+                }
+            }
+        }
+
+        $this->taskScheduler->cancelAllTasks();
+        $this->taskScheduler->shutdown();
+        
+        $this->interface->shutdown();
+
+        $duration = round(microtime(true) - $shutdownStart, 3);
+        $this->logger->info("Shutdown completed in {$duration}s.");
+
+        $this->handleRestartThrottle();
+        $this->logger->shutdown();
+        
+        // Ensure the process actually dies (force kill self)
+        // We use exit(0) to signal to the OS that this was a purposeful, clean shutdown.
+        @ProxyUtils::kill(ProxyUtils::pid()); 
+        exit(0);
+    }
+
+    /**
+     * Prevents the server from restarting too quickly if it was only up for a few seconds.
+     * This saves CPU/Disk if the server is in a crash-loop.
+     */
+    private function handleRestartThrottle() : void 
+    {
+        $uptime = time() - (int)$this->startProcessTime;
+        $minUptime = 10;
+        
+        if ($uptime < $minUptime) {
+            $spacing = $minUptime - $uptime;
+            echo PHP_EOL . "--- [AquaRelay] Server ran for only {$uptime}s. Waiting {$spacing}s before exit ---" . PHP_EOL;
+            echo "--- (Press Ctrl+C to skip wait) ---" . PHP_EOL;
+            sleep($spacing);
+        }
+    }
 }

--- a/src/config/Config.php
+++ b/src/config/Config.php
@@ -1,0 +1,119 @@
+<?php
+
+/*
+ * _____      _
+ * /\                    |  __ \    | |
+ * /  \   __ _ _   _  __ _| |__) |___| | __ _ _   _
+ * / /\ \ / _` | | | |/ _` |  _  // _ \ |/ _` | | | |
+ * / ____ \ (_| | |_| | (_| | | \ \  __/ | (_| | |_| |
+ * /_/    \_\__, |\__,_|\__,_|_|  \_\___|_|\__,_|\__, |
+ * |_|                                |___/
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author AquaRelay Team
+ * @link https://www.aquarelay.dev/
+ *
+ */
+
+declare(strict_types=1);
+
+namespace aquarelay\config;
+
+use Symfony\Component\Yaml\Yaml;
+use function file_exists;
+use function file_put_contents;
+
+/**
+ * Configuration manager for plugins
+ */
+class Config {
+
+    private array $data = [];
+    private string $filePath;
+
+    public function __construct(string $filePath)
+    {
+        $this->filePath = $filePath;
+        if (file_exists($this->filePath)) {
+            $this->data = Yaml::parseFile($this->filePath) ?? [];
+        }
+    }
+
+    /**
+     * Gets a value from the config
+     */
+    public function get(string $key, $default = null)
+    {
+        return $this->data[$key] ?? $default;
+    }
+
+    /**
+     * Sets a value in the config
+     */
+    public function set(string $key, $value) : void
+    {
+        $this->data[$key] = $value;
+    }
+
+    /**
+     * Removes a value from the config
+     */
+    public function remove(string $key) : void
+    {
+        if (isset($this->data[$key])) {
+            unset($this->data[$key]);
+        }
+    }
+
+    /**
+     * Sets default values.
+     * These will only be applied if the key does not already exist.
+     */
+    public function setDefaults(array $defaults) : void
+    {
+        $this->data += $defaults;
+    }
+
+    /**
+     * Loads a default configuration file and merges it.
+     * Existing values in the current config will take precedence.
+     */
+    public function loadDefault(string $defaultFilePath) : void
+    {
+        if (file_exists($defaultFilePath)) {
+            $defaults = Yaml::parseFile($defaultFilePath) ?? [];
+            $this->setDefaults($defaults);
+        }
+    }
+
+	/**
+	 * Saves the default config if it doesn't exist
+	 */
+	public function saveDefaultConfig() : void
+	{
+		if (!file_exists($this->filePath)) {
+			file_put_contents($this->filePath, Yaml::dump($this->data));
+		}
+	}
+
+
+    /**
+     * Saves the config to file
+     */
+    public function save() : void
+    {
+        file_put_contents($this->filePath, Yaml::dump($this->data));
+    }
+
+    /**
+     * Gets all config data
+     */
+    public function getAll() : array
+    {
+        return $this->data;
+    }
+}

--- a/src/network/ProxyLoop.php
+++ b/src/network/ProxyLoop.php
@@ -43,25 +43,34 @@ class ProxyLoop {
 		);
 	}
 
-	public function run() : void{
-		while(true){
-			$this->tick();
-			usleep(1000);
-		}
-	}
+	public function run() : void {
+        $tickInterval = 0.05;
+        $nextTick = microtime(true);
 
-	private function tick() : void {
-		$this->server->interface->tick();
-		
-		$this->server->getScheduler()->processAll();
+        while(true) {
+            $now = microtime(true);
 
-		foreach($this->sessions as $session) {
-			$player = $session->getPlayer();
-			if($player !== null && $player->getDownstream() !== null) {
-				$player->getDownstream()->tick(function($payload) use ($player) {});
-			}
-		}
-	}
+            $this->server->interface->tick(); 
+
+            if ($now >= $nextTick) {
+                $this->tick();
+                $nextTick += $tickInterval;
+            }
+
+            usleep(1000); 
+        }
+    }
+
+    private function tick() : void {
+        $this->server->getScheduler()->processAll();
+
+        foreach($this->sessions as $session) {
+            $player = $session->getPlayer();
+            if($player !== null && $player->getDownstream() !== null) {
+                $player->getDownstream()->tick(function($payload) use ($player) {});
+            }
+        }
+    }
 
 	private function handleConnect(int $sessionId, string $ip, int $port): void {
 		$this->server->getLogger()->info("Client connected: $ip:$port (ID: $sessionId)");

--- a/src/network/ProxyLoop.php
+++ b/src/network/ProxyLoop.php
@@ -26,15 +26,21 @@ namespace aquarelay\network;
 use aquarelay\network\raklib\RakLibPacketSender;
 use aquarelay\ProxyServer;
 use pocketmine\network\mcpe\protocol\PacketPool;
+use pocketmine\snooze\SleeperHandler;
 
 class ProxyLoop {
 
 	/** @var NetworkSession[] */
 	private array $sessions = [];
 
+	private SleeperHandler $sleeper;
+
+	const TICK_INTERVAL = 0.05;
+
 	public function __construct(
 		private ProxyServer $server
 	){
+		$this->sleeper = new SleeperHandler();
 		$this->server->interface->setHandlers(
 			$this->handleConnect(...),
 			$this->handlePacket(...),
@@ -44,20 +50,19 @@ class ProxyLoop {
 	}
 
 	public function run() : void {
-        $tickInterval = 0.05;
         $nextTick = microtime(true);
 
         while(true) {
             $now = microtime(true);
 
-            $this->server->interface->tick(); 
+            $this->server->interface->tick();
 
             if ($now >= $nextTick) {
                 $this->tick();
-                $nextTick += $tickInterval;
+                $nextTick += self::TICK_INTERVAL;
             }
 
-            usleep(1000); 
+            $this->sleeper->sleepUntil($nextTick);
         }
     }
 

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -101,4 +101,8 @@ class Player
 
 		$this->sendDataPacket($packet);
 	}
+
+	public function disconnect(string $reason = "Disconnected from proxy"): void {
+		$this->upstreamSession->disconnect($reason);
+	}
 }

--- a/src/plugin/Plugin.php
+++ b/src/plugin/Plugin.php
@@ -23,8 +23,14 @@ declare(strict_types=1);
 
 namespace aquarelay\plugin;
 
+use aquarelay\config\Config;
 use aquarelay\ProxyServer;
 use aquarelay\task\TaskScheduler;
+use Symfony\Component\Yaml\Yaml;
+
+use function file_exists;
+use function is_dir;
+use function mkdir;
 
 /**
  * Base class for all AquaRelay plugins
@@ -34,6 +40,8 @@ abstract class Plugin {
 	private PluginDescription $description;
 	private ProxyServer $server;
 	private bool $enabled = false;
+	private string $dataFolder;
+	private ?Config $config = null;
 
 	/**
 	 * Called when the plugin is loaded
@@ -135,5 +143,36 @@ abstract class Plugin {
 	public function getScheduler() : TaskScheduler
 	{
 		return $this->server->getScheduler();
+	}
+
+	/**
+	 * Sets the data folder for the plugin
+	 */
+	public function setDataFolder(string $dataFolder) : void
+	{
+		$this->dataFolder = $dataFolder;
+		if (!is_dir($this->dataFolder)) {
+			mkdir($this->dataFolder, 0755, true);
+		}
+	}
+
+	/**
+	 * Gets the data folder for the plugin
+	 */
+	public function getDataFolder() : string
+	{
+		return $this->dataFolder;
+	}
+
+	/**
+	 * Gets the config object
+	 */
+	public function getConfig() : Config
+	{
+		if ($this->config === null) {
+			$configPath = $this->dataFolder . DIRECTORY_SEPARATOR . 'config.yml';
+			$this->config = new Config($configPath);
+		}
+		return $this->config;
 	}
 }

--- a/src/task/DelayedTask.php
+++ b/src/task/DelayedTask.php
@@ -46,8 +46,8 @@ class DelayedTask extends Task {
 
 	public function onRun() : void {
 		$this->elapsedTicks++;
-		
-		if ($this->elapsedTicks >= $this->delay && !$this->isCancelled()) {
+
+		if ($this->elapsedTicks >= $this->delay && !$this->task->isCancelled() && !$this->isCancelled()) {
 			$this->task->onRun();
 		}
 	}

--- a/src/task/RepeatingTask.php
+++ b/src/task/RepeatingTask.php
@@ -54,7 +54,7 @@ class RepeatingTask extends Task {
 	public function onRun() : void {
 		$this->elapsedTicks++;
 		
-		if ($this->elapsedTicks >= $this->delay && ($this->elapsedTicks - $this->delay) % $this->period === 0 && !$this->isCancelled()) {
+		if ($this->elapsedTicks >= $this->delay && ($this->elapsedTicks - $this->delay) % $this->period === 0 && !$this->task->isCancelled() && !$this->isCancelled()) {
 			$this->task->onRun();
 		}
 	}

--- a/src/utils/ProxyUtils.php
+++ b/src/utils/ProxyUtils.php
@@ -1,0 +1,107 @@
+<?php
+
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU Lesser General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * @author AquaRelay Team
+ * @link https://www.aquarelay.dev/
+ */
+
+declare(strict_types=1);
+
+namespace aquarelay\utils;
+
+class ProxyUtils {
+
+    public const OS_WINDOWS = "win";
+    public const OS_IOS = "ios";
+    public const OS_MACOS = "mac";
+    public const OS_ANDROID = "android";
+    public const OS_LINUX = "linux";
+    public const OS_BSD = "bsd";
+    public const OS_UNKNOWN = "other";
+
+    private static ?string $os = null;
+
+    /**
+     * Kill a process by its PID.
+     * * @param int $pid The Process ID to kill
+     * @param bool $subprocesses If true, attempts to kill the process tree (subprocesses)
+     */
+    public static function kill(int $pid, bool $subprocesses = false): void {
+        $os = self::getOS();
+        
+        if ($os === self::OS_WINDOWS) {
+            $command = sprintf(
+                "taskkill.exe /F %s /PID %d > NUL 2> NUL",
+                $subprocesses ? "/T" : "",
+                $pid
+            );
+            exec($command);
+            return;
+        }
+
+        if (function_exists('posix_kill')) {
+            $targetPid = $subprocesses ? -$pid : $pid;
+            
+            if (@posix_kill($targetPid, 9)) {
+                return;
+            }
+        }
+
+        $cmdPid = $subprocesses ? "-" . $pid : (string)$pid;
+        exec("kill -9 " . escapeshellarg($cmdPid) . " > /dev/null 2>&1");
+    }
+
+    /**
+     * Get the current Operating System.
+     * * @param bool $recalculate Force recalculation of the OS
+     * @return string one of the ProxyUtils::OS_* constants
+     */
+    public static function getOS(bool $recalculate = false): string {
+        if (self::$os === null || $recalculate) {
+            $uname = php_uname("s");
+            $machine = php_uname("m");
+
+            if (stripos($uname, "Win") !== false || $uname === "Msys") {
+                self::$os = self::OS_WINDOWS;
+                return self::$os;
+            }
+
+            self::$os = match (true) {
+                stripos($uname, "Darwin") !== false => str_starts_with($machine, "iP") 
+                    ? self::OS_IOS 
+                    : self::OS_MACOS,
+                
+                stripos($uname, "Linux") !== false => @file_exists("/system/build.prop") 
+                    ? self::OS_ANDROID 
+                    : self::OS_LINUX,
+                
+                stripos($uname, "BSD") !== false, 
+                $uname === "DragonFly" => self::OS_BSD,
+                
+                default => self::OS_UNKNOWN,
+            };
+        }
+
+        return self::$os;
+    }
+
+    public static function pid() : int{
+		$result = getmypid();
+		if($result === false){
+			throw new \LogicException("getmypid() doesn't work on this platform");
+		}
+		return $result;
+	}
+    
+    /**
+     * Helper to check if the current OS is Windows
+     */
+    public static function isWindows(): bool {
+        return self::getOS() === self::OS_WINDOWS;
+    }
+}

--- a/src/utils/ProxyUtils.php
+++ b/src/utils/ProxyUtils.php
@@ -1,6 +1,14 @@
 <?php
 
 /*
+ *                            _____      _
+ *     /\                    |  __ \    | |
+ *    /  \   __ _ _   _  __ _| |__) |___| | __ _ _   _
+ *   / /\ \ / _` | | | |/ _` |  _  // _ \ |/ _` | | | |
+ *  / ____ \ (_| | |_| | (_| | | \ \  __/ | (_| | |_| |
+ * /_/    \_\__, |\__,_|\__,_|_|  \_\___|_|\__,_|\__, |
+ *             |_|                                |___/
+ *
  * This program is free software: you can redistribute it and/or modify
  * it under the terms of the GNU Lesser General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
@@ -8,8 +16,8 @@
  *
  * @author AquaRelay Team
  * @link https://www.aquarelay.dev/
+ *
  */
-
 declare(strict_types=1);
 
 namespace aquarelay\utils;

--- a/src/utils/Utils.php
+++ b/src/utils/Utils.php
@@ -22,7 +22,7 @@ declare(strict_types=1);
 
 namespace aquarelay\utils;
 
-class ProxyUtils {
+class Utils {
 
     public const OS_WINDOWS = "win";
     public const OS_IOS = "ios";
@@ -67,7 +67,7 @@ class ProxyUtils {
     /**
      * Get the current Operating System.
      * * @param bool $recalculate Force recalculation of the OS
-     * @return string one of the ProxyUtils::OS_* constants
+     * @return string one of the Utils::OS_* constants
      */
     public static function getOS(bool $recalculate = false): string {
         if (self::$os === null || $recalculate) {


### PR DESCRIPTION
Why I changed the loop:
1. Fixed the "Speed Hack" Bug The old code was running the game logic way too fast. Because we were sleeping for only 1ms, the server was ticking about 1,000 times a second instead of the standard 20. This messed up all the tasks—a 30-second timer was finishing in less than a second because the loop was sprinting.

2. Kept the Ping Low I didn't want to just slow the whole server down to 20 TPS, because that would make the network laggy (players would have to wait 50ms for the server to react). So, I split the loop: the network still runs as fast as possible (instant reaction), but the game logic waits its turn to ensure it only runs 20 times a second.

3. Stability This decouples "network time" from "game time." Now, even if the network is busy, our game ticks stay accurate, and tasks run exactly when they are supposed to.