### PR TITLE
Fix backend transfers

### DIFF
--- a/composer.lock
+++ b/composer.lock
@@ -729,16 +729,16 @@
         },
         {
             "name": "symfony/filesystem",
-            "version": "v6.4.37",
+            "version": "v6.4.39",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "29f792d7dc30cc670fc4cdd50d7c6653d067ce7b"
+                "reference": "c507b077756b4e3e09adbbe7975fac81cd3722ca"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/29f792d7dc30cc670fc4cdd50d7c6653d067ce7b",
-                "reference": "29f792d7dc30cc670fc4cdd50d7c6653d067ce7b",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/c507b077756b4e3e09adbbe7975fac81cd3722ca",
+                "reference": "c507b077756b4e3e09adbbe7975fac81cd3722ca",
                 "shasum": ""
             },
             "require": {
@@ -775,7 +775,7 @@
             "description": "Provides basic utilities for the filesystem",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/filesystem/tree/v6.4.37"
+                "source": "https://github.com/symfony/filesystem/tree/v6.4.39"
             },
             "funding": [
                 {
@@ -795,7 +795,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-13T15:27:04+00:00"
+            "time": "2026-05-07T13:11:42+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -967,16 +967,16 @@
         },
         {
             "name": "symfony/yaml",
-            "version": "v7.4.10",
+            "version": "v7.4.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/yaml.git",
-                "reference": "c660d6538545a3e8e65a5621ee3d7a6d352892c7"
+                "reference": "e2eb64a57763815ccae07ac1c7653d6cc1c326fd"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/yaml/zipball/c660d6538545a3e8e65a5621ee3d7a6d352892c7",
-                "reference": "c660d6538545a3e8e65a5621ee3d7a6d352892c7",
+                "url": "https://api.github.com/repos/symfony/yaml/zipball/e2eb64a57763815ccae07ac1c7653d6cc1c326fd",
+                "reference": "e2eb64a57763815ccae07ac1c7653d6cc1c326fd",
                 "shasum": ""
             },
             "require": {
@@ -1019,7 +1019,7 @@
             "description": "Loads and dumps YAML files",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/yaml/tree/v7.4.10"
+                "source": "https://github.com/symfony/yaml/tree/v7.4.11"
             },
             "funding": [
                 {
@@ -1039,7 +1039,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-05-05T08:01:55+00:00"
+            "time": "2026-05-13T12:04:42+00:00"
         }
     ],
     "packages-dev": [
@@ -1508,16 +1508,16 @@
         },
         {
             "name": "friendsofphp/php-cs-fixer",
-            "version": "v3.95.1",
+            "version": "v3.95.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer.git",
-                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065"
+                "reference": "a28d88a5e172b27e78d0816992b15a9df3da20f1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a9727678fbd12997f1d9de8f4a37824ed9df1065",
-                "reference": "a9727678fbd12997f1d9de8f4a37824ed9df1065",
+                "url": "https://api.github.com/repos/PHP-CS-Fixer/PHP-CS-Fixer/zipball/a28d88a5e172b27e78d0816992b15a9df3da20f1",
+                "reference": "a28d88a5e172b27e78d0816992b15a9df3da20f1",
                 "shasum": ""
             },
             "require": {
@@ -1549,8 +1549,8 @@
                 "symfony/stopwatch": "^5.4.45 || ^6.4.24 || ^7.0 || ^8.0"
             },
             "require-dev": {
-                "facile-it/paraunit": "^1.3.1 || ^2.8.0",
-                "infection/infection": "^0.32.6",
+                "facile-it/paraunit": "^1.3.1 || ^2.11.0",
+                "infection/infection": "^0.32.7",
                 "justinrainbow/json-schema": "^6.8.0",
                 "keradus/cli-executor": "^2.3",
                 "mikey179/vfsstream": "^1.6.12",
@@ -1601,7 +1601,7 @@
             ],
             "support": {
                 "issues": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/issues",
-                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.1"
+                "source": "https://github.com/PHP-CS-Fixer/PHP-CS-Fixer/tree/v3.95.2"
             },
             "funding": [
                 {
@@ -1609,7 +1609,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2026-04-12T17:00:09+00:00"
+            "time": "2026-05-15T09:20:44+00:00"
         },
         {
             "name": "psr/container",
@@ -2292,29 +2292,29 @@
         },
         {
             "name": "sebastian/diff",
-            "version": "6.0.2",
+            "version": "8.3.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/diff.git",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544"
+                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b4ccd857127db5d41a5b676f24b51371d76d8544",
-                "reference": "b4ccd857127db5d41a5b676f24b51371d76d8544",
+                "url": "https://api.github.com/repos/sebastianbergmann/diff/zipball/b36d33b6e796513de7cb7df053afb3f55eefcd47",
+                "reference": "b36d33b6e796513de7cb7df053afb3f55eefcd47",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "phpunit/phpunit": "^11.0",
-                "symfony/process": "^4.2 || ^5"
+                "phpunit/phpunit": "^13.0",
+                "symfony/process": "^7.2"
             },
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-main": "6.0-dev"
+                    "dev-main": "8.3-dev"
                 }
             },
             "autoload": {
@@ -2347,59 +2347,63 @@
             "support": {
                 "issues": "https://github.com/sebastianbergmann/diff/issues",
                 "security": "https://github.com/sebastianbergmann/diff/security/policy",
-                "source": "https://github.com/sebastianbergmann/diff/tree/6.0.2"
+                "source": "https://github.com/sebastianbergmann/diff/tree/8.3.0"
             },
             "funding": [
                 {
                     "url": "https://github.com/sebastianbergmann",
                     "type": "github"
+                },
+                {
+                    "url": "https://liberapay.com/sebastianbergmann",
+                    "type": "liberapay"
+                },
+                {
+                    "url": "https://thanks.dev/u/gh/sebastianbergmann",
+                    "type": "thanks_dev"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/sebastian/diff",
+                    "type": "tidelift"
                 }
             ],
-            "time": "2024-07-03T04:53:05+00:00"
+            "time": "2026-05-15T04:58:09+00:00"
         },
         {
             "name": "symfony/console",
-            "version": "v7.4.9",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58"
+                "reference": "3156577f46a38aa1b9323aad223de7a9cd426782"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/d7d2b64a45a89d607865927b176fa51c33ddbb58",
-                "reference": "d7d2b64a45a89d607865927b176fa51c33ddbb58",
+                "url": "https://api.github.com/repos/symfony/console/zipball/3156577f46a38aa1b9323aad223de7a9cd426782",
+                "reference": "3156577f46a38aa1b9323aad223de7a9cd426782",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3",
-                "symfony/polyfill-mbstring": "~1.0",
+                "php": ">=8.4",
+                "symfony/polyfill-mbstring": "^1.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/string": "^7.2|^8.0"
-            },
-            "conflict": {
-                "symfony/dependency-injection": "<6.4",
-                "symfony/dotenv": "<6.4",
-                "symfony/event-dispatcher": "<6.4",
-                "symfony/lock": "<6.4",
-                "symfony/process": "<6.4"
+                "symfony/string": "^7.4|^8.0"
             },
             "provide": {
                 "psr/log-implementation": "1.0|2.0|3.0"
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/event-dispatcher": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
-                "symfony/http-kernel": "^6.4|^7.0|^8.0",
-                "symfony/lock": "^6.4|^7.0|^8.0",
-                "symfony/messenger": "^6.4|^7.0|^8.0",
-                "symfony/process": "^6.4|^7.0|^8.0",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0",
-                "symfony/var-dumper": "^6.4|^7.0|^8.0"
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/event-dispatcher": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
+                "symfony/http-kernel": "^7.4|^8.0",
+                "symfony/lock": "^7.4|^8.0",
+                "symfony/messenger": "^7.4|^8.0",
+                "symfony/process": "^7.4|^8.0",
+                "symfony/stopwatch": "^7.4|^8.0",
+                "symfony/var-dumper": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2433,7 +2437,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v7.4.9"
+                "source": "https://github.com/symfony/console/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -2453,28 +2457,28 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-22T15:21:55+00:00"
+            "time": "2026-05-13T12:07:53+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v7.4.9",
+            "version": "v8.0.9",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101"
+                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/e4a2e29753c7801f7a8340e066cfa788f3bc8101",
-                "reference": "e4a2e29753c7801f7a8340e066cfa788f3bc8101",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0c3c1a17604c4dbbec4b93fe162c538482096e1f",
+                "reference": "0c3c1a17604c4dbbec4b93fe162c538482096e1f",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/event-dispatcher-contracts": "^2.5|^3"
             },
             "conflict": {
-                "symfony/dependency-injection": "<6.4",
+                "symfony/security-http": "<7.4",
                 "symfony/service-contracts": "<2.5"
             },
             "provide": {
@@ -2483,14 +2487,14 @@
             },
             "require-dev": {
                 "psr/log": "^1|^2|^3",
-                "symfony/config": "^6.4|^7.0|^8.0",
-                "symfony/dependency-injection": "^6.4|^7.0|^8.0",
-                "symfony/error-handler": "^6.4|^7.0|^8.0",
-                "symfony/expression-language": "^6.4|^7.0|^8.0",
-                "symfony/framework-bundle": "^6.4|^7.0|^8.0",
-                "symfony/http-foundation": "^6.4|^7.0|^8.0",
+                "symfony/config": "^7.4|^8.0",
+                "symfony/dependency-injection": "^7.4|^8.0",
+                "symfony/error-handler": "^7.4|^8.0",
+                "symfony/expression-language": "^7.4|^8.0",
+                "symfony/framework-bundle": "^7.4|^8.0",
+                "symfony/http-foundation": "^7.4|^8.0",
                 "symfony/service-contracts": "^2.5|^3",
-                "symfony/stopwatch": "^6.4|^7.0|^8.0"
+                "symfony/stopwatch": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2518,7 +2522,7 @@
             "description": "Provides tools that allow your application components to communicate with each other by dispatching events and listening to them",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/event-dispatcher/tree/v7.4.9"
+                "source": "https://github.com/symfony/event-dispatcher/tree/v8.0.9"
             },
             "funding": [
                 {
@@ -2538,7 +2542,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-04-18T13:18:21+00:00"
+            "time": "2026-04-18T13:51:42+00:00"
         },
         {
             "name": "symfony/event-dispatcher-contracts",
@@ -2622,23 +2626,23 @@
         },
         {
             "name": "symfony/finder",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149"
+                "reference": "8da41214757b87d97f181e3d14a4179286151007"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/e0be088d22278583a82da281886e8c3592fbf149",
-                "reference": "e0be088d22278583a82da281886e8c3592fbf149",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8da41214757b87d97f181e3d14a4179286151007",
+                "reference": "8da41214757b87d97f181e3d14a4179286151007",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "require-dev": {
-                "symfony/filesystem": "^6.4|^7.0|^8.0"
+                "symfony/filesystem": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -2666,7 +2670,7 @@
             "description": "Finds files and directories via an intuitive fluent interface",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/finder/tree/v7.4.8"
+                "source": "https://github.com/symfony/finder/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -2686,24 +2690,24 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/options-resolver",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/options-resolver.git",
-                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4"
+                "reference": "b48bce0a70b914f6953dafbd10474df232ed4de8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
-                "reference": "2888fcdc4dc2fd5f7c7397be78631e8af12e02b4",
+                "url": "https://api.github.com/repos/symfony/options-resolver/zipball/b48bce0a70b914f6953dafbd10474df232ed4de8",
+                "reference": "b48bce0a70b914f6953dafbd10474df232ed4de8",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/deprecation-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -2737,7 +2741,7 @@
                 "options"
             ],
             "support": {
-                "source": "https://github.com/symfony/options-resolver/tree/v7.4.8"
+                "source": "https://github.com/symfony/options-resolver/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -2757,7 +2761,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/polyfill-intl-grapheme",
@@ -3172,20 +3176,20 @@
         },
         {
             "name": "symfony/process",
-            "version": "v7.4.8",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a"
+                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/60f19cd3badc8de688421e21e4305eba50f8089a",
-                "reference": "60f19cd3badc8de688421e21e4305eba50f8089a",
+                "url": "https://api.github.com/repos/symfony/process/zipball/26d89e459f037d2873300605d0a07e7a8ef84db0",
+                "reference": "26d89e459f037d2873300605d0a07e7a8ef84db0",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2"
+                "php": ">=8.4"
             },
             "type": "library",
             "autoload": {
@@ -3213,7 +3217,7 @@
             "description": "Executes commands in sub-processes",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/process/tree/v7.4.8"
+                "source": "https://github.com/symfony/process/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -3233,7 +3237,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-11T16:56:32+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -3324,20 +3328,20 @@
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v7.4.8",
+            "version": "v8.0.8",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89"
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
-                "reference": "70a852d72fec4d51efb1f48dcd968efcaf5ccb89",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
+                "reference": "85954ed72d5440ea4dc9a10b7e49e01df766ffa3",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
+                "php": ">=8.4",
                 "symfony/service-contracts": "^2.5|^3"
             },
             "type": "library",
@@ -3366,7 +3370,7 @@
             "description": "Provides a way to profile code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/stopwatch/tree/v7.4.8"
+                "source": "https://github.com/symfony/stopwatch/tree/v8.0.8"
             },
             "funding": [
                 {
@@ -3386,39 +3390,38 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-03-30T15:14:47+00:00"
         },
         {
             "name": "symfony/string",
-            "version": "v7.4.8",
+            "version": "v8.0.11",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688"
+                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/114ac57257d75df748eda23dd003878080b8e688",
-                "reference": "114ac57257d75df748eda23dd003878080b8e688",
+                "url": "https://api.github.com/repos/symfony/string/zipball/39be2ad058a3c0bd558edca23e65f009865d75ff",
+                "reference": "39be2ad058a3c0bd558edca23e65f009865d75ff",
                 "shasum": ""
             },
             "require": {
-                "php": ">=8.2",
-                "symfony/deprecation-contracts": "^2.5|^3.0",
-                "symfony/polyfill-ctype": "~1.8",
-                "symfony/polyfill-intl-grapheme": "~1.33",
-                "symfony/polyfill-intl-normalizer": "~1.0",
-                "symfony/polyfill-mbstring": "~1.0"
+                "php": ">=8.4",
+                "symfony/polyfill-ctype": "^1.8",
+                "symfony/polyfill-intl-grapheme": "^1.33",
+                "symfony/polyfill-intl-normalizer": "^1.0",
+                "symfony/polyfill-mbstring": "^1.0"
             },
             "conflict": {
                 "symfony/translation-contracts": "<2.5"
             },
             "require-dev": {
-                "symfony/emoji": "^7.1|^8.0",
-                "symfony/http-client": "^6.4|^7.0|^8.0",
-                "symfony/intl": "^6.4|^7.0|^8.0",
+                "symfony/emoji": "^7.4|^8.0",
+                "symfony/http-client": "^7.4|^8.0",
+                "symfony/intl": "^7.4|^8.0",
                 "symfony/translation-contracts": "^2.5|^3.0",
-                "symfony/var-exporter": "^6.4|^7.0|^8.0"
+                "symfony/var-exporter": "^7.4|^8.0"
             },
             "type": "library",
             "autoload": {
@@ -3457,7 +3460,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v7.4.8"
+                "source": "https://github.com/symfony/string/tree/v8.0.11"
             },
             "funding": [
                 {
@@ -3477,7 +3480,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2026-03-24T13:12:05+00:00"
+            "time": "2026-05-13T12:07:53+00:00"
         }
     ],
     "aliases": [],
@@ -3498,5 +3501,5 @@
         "ext-pcre": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.6.0"
+    "plugin-api-version": "2.9.0"
 }

--- a/src/command/SimpleCommandMap.php
+++ b/src/command/SimpleCommandMap.php
@@ -29,6 +29,7 @@ use aquarelay\command\default\ProxyPluginsCommand;
 use aquarelay\command\default\ProxyStopCommand;
 use aquarelay\command\default\ProxyTransferCommand;
 use aquarelay\command\sender\CommandSender;
+use aquarelay\command\utils\CommandStringHelper;
 use function array_shift;
 use function explode;
 use function str_starts_with;
@@ -73,7 +74,7 @@ class SimpleCommandMap implements CommandMap {
 
 	public function dispatch(CommandSender $sender, string $line) : bool
 	{
-		$args = explode(" ", trim($line));
+		$args = CommandStringHelper::parseQuoteAware($line);
 		$label = array_shift($args);
 
 		if ($label === null) {

--- a/src/command/utils/CommandStringHelper.php
+++ b/src/command/utils/CommandStringHelper.php
@@ -1,0 +1,28 @@
+<?php
+
+declare(strict_types=1);
+
+namespace aquarelay\command\utils;
+
+final class CommandStringHelper{
+
+	public static function parseQuoteAware(string $commandLine) : array{
+		$args = [];
+		preg_match_all('/"((?:\\\\.|[^\\\\"])*)"|(\S+)/u', $commandLine, $matches);
+
+		foreach($matches[0] as $k => $_){
+			for($i = 1; $i <= 2; ++$i){
+				if($matches[$i][$k] !== ""){
+					$match = $matches[$i][$k];
+
+					$args[] = preg_replace('/\\\\([\\\\"])/u', '$1', $match)
+						?? throw new \Error(preg_last_error_msg());
+
+					break;
+				}
+			}
+		}
+
+		return $args;
+	}
+}

--- a/src/network/handler/downstream/DownstreamInGameHandler.php
+++ b/src/network/handler/downstream/DownstreamInGameHandler.php
@@ -27,9 +27,14 @@ namespace aquarelay\network\handler\downstream;
 use aquarelay\event\default\player\PlayerJoinEvent;
 use pocketmine\network\mcpe\protocol\AddActorPacket;
 use pocketmine\network\mcpe\protocol\AddPlayerPacket;
+use pocketmine\network\mcpe\protocol\AnimatePacket;
 use pocketmine\network\mcpe\protocol\AvailableCommandsPacket;
 use pocketmine\network\mcpe\protocol\BossEventPacket;
 use pocketmine\network\mcpe\protocol\DisconnectPacket;
+use pocketmine\network\mcpe\protocol\LevelChunkPacket;
+use pocketmine\network\mcpe\protocol\MobEffectPacket;
+use pocketmine\network\mcpe\protocol\MovePlayerPacket;
+use pocketmine\network\mcpe\protocol\NetworkChunkPublisherUpdatePacket;
 use pocketmine\network\mcpe\protocol\PlayerListPacket;
 use pocketmine\network\mcpe\protocol\PlayStatusPacket;
 use pocketmine\network\mcpe\protocol\RemoveActorPacket;
@@ -37,7 +42,10 @@ use pocketmine\network\mcpe\protocol\RemoveObjectivePacket;
 use pocketmine\network\mcpe\protocol\RequestChunkRadiusPacket;
 use pocketmine\network\mcpe\protocol\serializer\AvailableCommandsPacketAssembler;
 use pocketmine\network\mcpe\protocol\serializer\AvailableCommandsPacketDisassembler;
+use pocketmine\network\mcpe\protocol\SetActorDataPacket;
+use pocketmine\network\mcpe\protocol\SetActorMotionPacket;
 use pocketmine\network\mcpe\protocol\SetDisplayObjectivePacket;
+use pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket;
 use pocketmine\network\mcpe\protocol\StartGamePacket;
 use pocketmine\network\mcpe\protocol\TransferPacket;
 use pocketmine\network\mcpe\protocol\types\command\CommandData;
@@ -45,6 +53,7 @@ use pocketmine\network\mcpe\protocol\types\command\CommandHardEnum;
 use pocketmine\network\mcpe\protocol\types\command\CommandOverload;
 use pocketmine\network\mcpe\protocol\types\command\CommandParameter;
 use pocketmine\network\mcpe\protocol\types\command\CommandPermissions;
+use pocketmine\network\mcpe\protocol\UpdateAttributesPacket;
 use function array_map;
 use function in_array;
 use function strtolower;
@@ -52,6 +61,113 @@ use function ucfirst;
 
 class DownstreamInGameHandler extends AbstractDownstreamPacketHandler
 {
+
+	private function sendPostTransferSpawnInitialized() : void
+	{
+		$player = $this->getPlayer();
+		$rewriteData = $player->getRewriteData();
+		$downstream = $player->getDownstream();
+
+		if ($downstream === null || !$downstream->isConnected()) {
+			return;
+		}
+
+		if ($rewriteData->postTransferSpawnInitialized) {
+			return;
+		}
+
+		$rewriteData->postTransferSpawnInitialized = true;
+
+		$player->getNetworkSession()->getLogger()->debug(
+			"Sending post-transfer SetLocalPlayerAsInitialized to backend with runtimeId={$rewriteData->originalEntityId}"
+		);
+
+		$downstream->sendGamePacket(SetLocalPlayerAsInitializedPacket::create($rewriteData->originalEntityId));
+
+		$chunkRadiusPacket = new RequestChunkRadiusPacket();
+		$chunkRadiusPacket->radius = 8;
+		$chunkRadiusPacket->maxRadius = 8;
+
+		$downstream->sendGamePacket($chunkRadiusPacket);
+	}
+
+	private function rewriteLocalRuntimeId(int $runtimeId, string $packetName = "unknown") : int
+	{
+		$rewriteData = $this->getPlayer()->getRewriteData();
+
+		if ($runtimeId === $rewriteData->originalEntityId && $rewriteData->entityId !== 0) {
+			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
+				"RuntimeId rewrite in {$packetName}: backend={$runtimeId} -> client={$rewriteData->entityId}"
+			);
+
+			return $rewriteData->entityId;
+		}
+
+		if ($runtimeId === $rewriteData->entityId) {
+			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
+				"RuntimeId already client id in {$packetName}: {$runtimeId}"
+			);
+		}
+
+		return $runtimeId;
+	}
+
+	public function handleMovePlayer(MovePlayerPacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "MovePlayerPacket");
+		return false;
+	}
+
+	public function handleSetActorData(SetActorDataPacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "SetActorDataPacket");
+		return false;
+	}
+
+	public function handleSetActorMotion(SetActorMotionPacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "SetActorMotionPacket");
+		return false;
+	}
+
+	public function handleUpdateAttributes(UpdateAttributesPacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "UpdateAttributesPacket");
+		return false;
+	}
+
+	public function handleMobEffect(MobEffectPacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "MobEffectPacket");
+		return false;
+	}
+
+	public function handleAnimate(AnimatePacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "AnimatePacket");
+		return false;
+	}
+
+	public function handleLevelChunk(LevelChunkPacket $packet) : bool
+	{
+		static $chunkDebugCount = 0;
+
+		if ($chunkDebugCount < 20) {
+			++$chunkDebugCount;
+
+			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
+				"LevelChunk from backend after transfer: " .
+				"x={$packet->getChunkPosition()->getX()}, z={$packet->getChunkPosition()->getZ()}, count={$chunkDebugCount}"
+			);
+		}
+
+		return false;
+	}
+
+	public function handleNetworkChunkPublisherUpdate(NetworkChunkPublisherUpdatePacket $packet) : bool
+	{
+		return false;
+	}
 
 	public function handleAvailableCommands(AvailableCommandsPacket $packet) : bool{
 		$player = $this->getPlayer();
@@ -205,12 +321,22 @@ class DownstreamInGameHandler extends AbstractDownstreamPacketHandler
 			$this->getPlayer()->getNetworkSession()->getLogger()->debug('Suppressing duplicate LOGIN_SUCCESS from backend');
 			return true;
 		}
+
 		if ($packet->status === PlayStatusPacket::PLAYER_SPAWN) {
-			if ($this->getPlayer()->backendRuntimeId === null) {
-				$this->getPlayer()->getNetworkSession()->getLogger()->debug('Cannot send spawn notification: backendRuntimeId is null.');
+			$player = $this->getPlayer();
+			$rewriteData = $player->getRewriteData();
+
+			if ($rewriteData->entityId !== 0 && $rewriteData->originalEntityId !== $rewriteData->entityId) {
+				$this->sendPostTransferSpawnInitialized();
+
+				return false;
+			}
+
+			if ($player->backendRuntimeId === null) {
+				$player->getNetworkSession()->getLogger()->debug('Cannot send spawn notification: backendRuntimeId is null.');
 			} else {
-				$this->getPlayer()->getNetworkSession()->getLogger()->debug('Sending spawn notification, waiting for spawn response');
-				$event = new PlayerJoinEvent($this->getPlayer());
+				$player->getNetworkSession()->getLogger()->debug('Sending spawn notification, waiting for spawn response');
+				$event = new PlayerJoinEvent($player);
 				$event->call();
 			}
 		}

--- a/src/network/handler/downstream/DownstreamInGameHandler.php
+++ b/src/network/handler/downstream/DownstreamInGameHandler.php
@@ -61,7 +61,6 @@ use function ucfirst;
 
 class DownstreamInGameHandler extends AbstractDownstreamPacketHandler
 {
-
 	private function sendPostTransferSpawnInitialized() : void
 	{
 		$player = $this->getPlayer();
@@ -78,10 +77,6 @@ class DownstreamInGameHandler extends AbstractDownstreamPacketHandler
 
 		$rewriteData->postTransferSpawnInitialized = true;
 
-		$player->getNetworkSession()->getLogger()->debug(
-			"Sending post-transfer SetLocalPlayerAsInitialized to backend with runtimeId={$rewriteData->originalEntityId}"
-		);
-
 		$downstream->sendGamePacket(SetLocalPlayerAsInitializedPacket::create($rewriteData->originalEntityId));
 
 		$chunkRadiusPacket = new RequestChunkRadiusPacket();
@@ -91,81 +86,49 @@ class DownstreamInGameHandler extends AbstractDownstreamPacketHandler
 		$downstream->sendGamePacket($chunkRadiusPacket);
 	}
 
-	private function rewriteLocalRuntimeId(int $runtimeId, string $packetName = "unknown") : int
+	private function rewriteLocalRuntimeId(int $runtimeId) : int
 	{
 		$rewriteData = $this->getPlayer()->getRewriteData();
 
 		if ($runtimeId === $rewriteData->originalEntityId && $rewriteData->entityId !== 0) {
-			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
-				"RuntimeId rewrite in {$packetName}: backend={$runtimeId} -> client={$rewriteData->entityId}"
-			);
-
 			return $rewriteData->entityId;
 		}
-
-		if ($runtimeId === $rewriteData->entityId) {
-			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
-				"RuntimeId already client id in {$packetName}: {$runtimeId}"
-			);
-		}
-
 		return $runtimeId;
 	}
 
 	public function handleMovePlayer(MovePlayerPacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "MovePlayerPacket");
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleSetActorData(SetActorDataPacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "SetActorDataPacket");
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleSetActorMotion(SetActorMotionPacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "SetActorMotionPacket");
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleUpdateAttributes(UpdateAttributesPacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "UpdateAttributesPacket");
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleMobEffect(MobEffectPacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "MobEffectPacket");
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleAnimate(AnimatePacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId, "AnimatePacket");
-		return false;
-	}
-
-	public function handleLevelChunk(LevelChunkPacket $packet) : bool
-	{
-		static $chunkDebugCount = 0;
-
-		if ($chunkDebugCount < 20) {
-			++$chunkDebugCount;
-
-			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
-				"LevelChunk from backend after transfer: " .
-				"x={$packet->getChunkPosition()->getX()}, z={$packet->getChunkPosition()->getZ()}, count={$chunkDebugCount}"
-			);
-		}
-
-		return false;
-	}
-
-	public function handleNetworkChunkPublisherUpdate(NetworkChunkPublisherUpdatePacket $packet) : bool
-	{
+		$packet->actorRuntimeId = $this->rewriteLocalRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
@@ -336,6 +299,7 @@ class DownstreamInGameHandler extends AbstractDownstreamPacketHandler
 				$player->getNetworkSession()->getLogger()->debug('Cannot send spawn notification: backendRuntimeId is null.');
 			} else {
 				$player->getNetworkSession()->getLogger()->debug('Sending spawn notification, waiting for spawn response');
+
 				$event = new PlayerJoinEvent($player);
 				$event->call();
 			}

--- a/src/network/handler/downstream/SwitchDownstreamHandler.php
+++ b/src/network/handler/downstream/SwitchDownstreamHandler.php
@@ -27,12 +27,17 @@ namespace aquarelay\network\handler\downstream;
 use aquarelay\network\protocol\PlayerRewriteUtils;
 use aquarelay\network\protocol\TransferCallback;
 use pocketmine\network\mcpe\protocol\DisconnectPacket;
+use pocketmine\network\mcpe\protocol\LevelChunkPacket;
+use pocketmine\network\mcpe\protocol\NetworkChunkPublisherUpdatePacket;
 use pocketmine\network\mcpe\protocol\PlayStatusPacket;
 use pocketmine\network\mcpe\protocol\RequestChunkRadiusPacket;
+use pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket;
 use pocketmine\network\mcpe\protocol\StartGamePacket;
+use pocketmine\network\mcpe\protocol\types\DimensionIds;
 
 class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 {
+
 	public function handlePlayStatus(PlayStatusPacket $packet) : bool
 	{
 		if ($packet->status === PlayStatusPacket::PLAYER_SPAWN) {
@@ -45,13 +50,60 @@ class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 		return true;
 	}
 
+	public function handleLevelChunk(LevelChunkPacket $packet) : bool
+	{
+		$rewriteData = $this->getPlayer()->getRewriteData();
+
+		if ($rewriteData->transferCallback !== null) {
+			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
+				"Dropping LevelChunk during transfer: x={$packet->getChunkPosition()->getX()}, z={$packet->getChunkPosition()->getZ()}, phase={$rewriteData->transferCallback->getPhase()}"
+			);
+			return true;
+		}
+
+		$this->getPlayer()->getNetworkSession()->getLogger()->debug(
+			"Passing LevelChunk during switch: x={$packet->getChunkPosition()->getX()}, z={$packet->getChunkPosition()->getZ()}"
+		);
+		return false;
+	}
+
+	public function handleNetworkChunkPublisherUpdate(NetworkChunkPublisherUpdatePacket $packet) : bool
+	{
+		$rewriteData = $this->getPlayer()->getRewriteData();
+
+		if ($rewriteData->transferCallback !== null) {
+			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
+				"Dropping NetworkChunkPublisherUpdate during transfer"
+			);
+			return true;
+		}
+
+		$this->getPlayer()->getNetworkSession()->getLogger()->debug(
+			"Passing NetworkChunkPublisherUpdate during switch"
+		);
+		return false;
+	}
+
 	public function handleStartGame(StartGamePacket $packet) : bool
 	{
 		$player = $this->getPlayer();
 		$rewriteData = $player->getRewriteData();
 		$session = $player->getNetworkSession();
 
+		$oldBackendRuntimeId = $player->backendRuntimeId ?? -1;
+
 		$rewriteData->originalEntityId = $packet->actorRuntimeId;
+		$player->setBackendRuntimeId($packet->actorRuntimeId);
+
+		$session->getLogger()->debug(
+			"Switch StartGame received: " .
+			"newBackendRuntimeId={$packet->actorRuntimeId}, " .
+			"oldBackendRuntimeId={$oldBackendRuntimeId}, " .
+			"clientRuntimeId={$rewriteData->entityId}, " .
+			"spawn={$packet->playerPosition->x},{$packet->playerPosition->y},{$packet->playerPosition->z}, " .
+			"pitch={$packet->pitch}, yaw={$packet->yaw}"
+		);
+
 		$rewriteData->gameRules = $packet->levelSettings->gameRules;
 		$rewriteData->spawnPosition = $packet->playerPosition;
 		$rewriteData->pitch = $packet->pitch;
@@ -101,50 +153,87 @@ class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 		PlayerRewriteUtils::injectSetDifficulty($session, $packet->levelSettings->difficulty);
 		PlayerRewriteUtils::injectGameRules($session, $packet->levelSettings->gameRules);
 
-		$chunkRadiusPacket = new RequestChunkRadiusPacket();
-		$chunkRadiusPacket->radius = 8;
-		$chunkRadiusPacket->maxRadius = 8;
-		$player->sendToBackend($chunkRadiusPacket);
-
 		$targetDim = $packet->levelSettings->spawnSettings->getDimension();
-		$newDimension = PlayerRewriteUtils::determineDimensionId($rewriteData->dimension, $targetDim);
+		$oldDimension = $rewriteData->dimension;
+
+		$needsDimensionHop = $oldDimension === $targetDim;
+
+		$newDimension = $needsDimensionHop
+			? PlayerRewriteUtils::determineDimensionId($oldDimension, $targetDim)
+			: $targetDim;
 
 		$transferCallback = new TransferCallback($player, $oldServer, $targetDim);
-		$rewriteData->dimension = $newDimension;
 		$rewriteData->transferCallback = $transferCallback;
 
-		$fastTransfer = ($newDimension !== $targetDim);
+		$useFastTransfer = $player->getServer()->getConfig()->getMiscSettings()->getFastTransfer();
 
-		if ($fastTransfer) {
+		$startTransferWatchdog = function () use ($session, $player, $transferCallback, $useFastTransfer) : void {
+			$player->getServer()->getScheduler()->scheduleDelayed(function () use ($session, $player, $transferCallback, $useFastTransfer) : void {
+				if (!$session->isConnected()) {
+					return;
+				}
+				$rewriteData = $player->getRewriteData();
+
+				if ($rewriteData->transferCallback === $transferCallback && $transferCallback->getPhase() === TransferCallback::PHASE_1) {
+					$session->getLogger()->debug(($useFastTransfer ? "Fast" : "Safe") . " transfer stuck in PHASE_1, forcing callback");
+					$transferCallback->onDimChangeSuccess();
+				}
+			}, $useFastTransfer ? 20 : 60);
+
+			$player->getServer()->getScheduler()->scheduleDelayed(function () use ($session, $player, $transferCallback, $useFastTransfer) : void {
+				if (!$session->isConnected()) {
+					return;
+				}
+				$rewriteData = $player->getRewriteData();
+
+				if ($rewriteData->transferCallback === $transferCallback && $transferCallback->getPhase() === TransferCallback::PHASE_2) {
+					$session->getLogger()->debug(($useFastTransfer ? "Fast" : "Safe") . " transfer stuck in PHASE_2, forcing callback");
+					$transferCallback->onDimChangeSuccess();
+				}
+			}, $useFastTransfer ? 45 : 100);
+		};
+
+		if ($useFastTransfer) {
 			$fakePosition = $packet->playerPosition->add(2000, 0, 2000);
 
 			PlayerRewriteUtils::injectPosition(
-				$session, $fakePosition, $packet->pitch, $packet->yaw, $rewriteData->entityId
+				$session,
+				$fakePosition,
+				$packet->pitch,
+				$packet->yaw,
+				$rewriteData->entityId
 			);
 
+			$rewriteData->dimension = $newDimension;
+
 			PlayerRewriteUtils::injectDimensionChange(
-				$session, $newDimension, $fakePosition, $rewriteData->entityId, true
+				$session,
+				$newDimension,
+				$fakePosition,
+				$rewriteData->entityId,
+				true
 			);
 
-			$player->getServer()->getScheduler()->scheduleDelayed(function () use ($session) {
-				if ($session->isConnected()) {
-					$session->sendDataPacket(PlayStatusPacket::create(PlayStatusPacket::PLAYER_SPAWN));
-				}
-			}, 40);
-		} elseif ($newDimension === $targetDim) {
-			PlayerRewriteUtils::injectPosition(
-				$session, $packet->playerPosition, $packet->pitch, $packet->yaw, $rewriteData->entityId
-			);
-			PlayerRewriteUtils::injectDimensionChange(
-				$session, $newDimension, $packet->playerPosition, $rewriteData->entityId, false
-			);
-			$transferCallback->onDimChangeSuccess();
-			$transferCallback->onDimChangeSuccess();
+			$startTransferWatchdog();
 		} else {
-			PlayerRewriteUtils::injectPosition(
-				$session, $packet->playerPosition, $packet->pitch, $packet->yaw, $rewriteData->entityId
+			$session->getLogger()->debug(
+				"Safe transfer: " .
+				"clientRuntimeId={$rewriteData->entityId}, " .
+				"backendRuntimeId={$rewriteData->originalEntityId}, " .
+				"targetDimension={$targetDim}, " .
+				"spawn={$packet->playerPosition->x},{$packet->playerPosition->y},{$packet->playerPosition->z}"
 			);
+
 			$rewriteData->dimension = $targetDim;
+
+			PlayerRewriteUtils::injectPosition(
+				$session,
+				$packet->playerPosition,
+				$packet->pitch,
+				$packet->yaw,
+				$rewriteData->entityId
+			);
+
 			$transferCallback->onDimChangeSuccess();
 			$transferCallback->onDimChangeSuccess();
 		}

--- a/src/network/handler/downstream/SwitchDownstreamHandler.php
+++ b/src/network/handler/downstream/SwitchDownstreamHandler.php
@@ -37,11 +37,11 @@ use pocketmine\network\mcpe\protocol\types\DimensionIds;
 
 class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 {
-
 	public function handlePlayStatus(PlayStatusPacket $packet) : bool
 	{
 		if ($packet->status === PlayStatusPacket::PLAYER_SPAWN) {
 			$rewriteData = $this->getPlayer()->getRewriteData();
+
 			if ($rewriteData->transferCallback !== null && $rewriteData->transferCallback->getPhase() === TransferCallback::PHASE_2) {
 				$rewriteData->transferCallback->onDimChangeSuccess();
 			}
@@ -55,15 +55,8 @@ class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 		$rewriteData = $this->getPlayer()->getRewriteData();
 
 		if ($rewriteData->transferCallback !== null) {
-			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
-				"Dropping LevelChunk during transfer: x={$packet->getChunkPosition()->getX()}, z={$packet->getChunkPosition()->getZ()}, phase={$rewriteData->transferCallback->getPhase()}"
-			);
 			return true;
 		}
-
-		$this->getPlayer()->getNetworkSession()->getLogger()->debug(
-			"Passing LevelChunk during switch: x={$packet->getChunkPosition()->getX()}, z={$packet->getChunkPosition()->getZ()}"
-		);
 		return false;
 	}
 
@@ -72,15 +65,8 @@ class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 		$rewriteData = $this->getPlayer()->getRewriteData();
 
 		if ($rewriteData->transferCallback !== null) {
-			$this->getPlayer()->getNetworkSession()->getLogger()->debug(
-				"Dropping NetworkChunkPublisherUpdate during transfer"
-			);
 			return true;
 		}
-
-		$this->getPlayer()->getNetworkSession()->getLogger()->debug(
-			"Passing NetworkChunkPublisherUpdate during switch"
-		);
 		return false;
 	}
 
@@ -90,19 +76,8 @@ class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 		$rewriteData = $player->getRewriteData();
 		$session = $player->getNetworkSession();
 
-		$oldBackendRuntimeId = $player->backendRuntimeId ?? -1;
-
 		$rewriteData->originalEntityId = $packet->actorRuntimeId;
 		$player->setBackendRuntimeId($packet->actorRuntimeId);
-
-		$session->getLogger()->debug(
-			"Switch StartGame received: " .
-			"newBackendRuntimeId={$packet->actorRuntimeId}, " .
-			"oldBackendRuntimeId={$oldBackendRuntimeId}, " .
-			"clientRuntimeId={$rewriteData->entityId}, " .
-			"spawn={$packet->playerPosition->x},{$packet->playerPosition->y},{$packet->playerPosition->z}, " .
-			"pitch={$packet->pitch}, yaw={$packet->yaw}"
-		);
 
 		$rewriteData->gameRules = $packet->levelSettings->gameRules;
 		$rewriteData->spawnPosition = $packet->playerPosition;
@@ -175,7 +150,6 @@ class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 				$rewriteData = $player->getRewriteData();
 
 				if ($rewriteData->transferCallback === $transferCallback && $transferCallback->getPhase() === TransferCallback::PHASE_1) {
-					$session->getLogger()->debug(($useFastTransfer ? "Fast" : "Safe") . " transfer stuck in PHASE_1, forcing callback");
 					$transferCallback->onDimChangeSuccess();
 				}
 			}, $useFastTransfer ? 20 : 60);
@@ -187,7 +161,6 @@ class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 				$rewriteData = $player->getRewriteData();
 
 				if ($rewriteData->transferCallback === $transferCallback && $transferCallback->getPhase() === TransferCallback::PHASE_2) {
-					$session->getLogger()->debug(($useFastTransfer ? "Fast" : "Safe") . " transfer stuck in PHASE_2, forcing callback");
 					$transferCallback->onDimChangeSuccess();
 				}
 			}, $useFastTransfer ? 45 : 100);
@@ -216,14 +189,6 @@ class SwitchDownstreamHandler extends AbstractDownstreamPacketHandler
 
 			$startTransferWatchdog();
 		} else {
-			$session->getLogger()->debug(
-				"Safe transfer: " .
-				"clientRuntimeId={$rewriteData->entityId}, " .
-				"backendRuntimeId={$rewriteData->originalEntityId}, " .
-				"targetDimension={$targetDim}, " .
-				"spawn={$packet->playerPosition->x},{$packet->playerPosition->y},{$packet->playerPosition->z}"
-			);
-
 			$rewriteData->dimension = $targetDim;
 
 			PlayerRewriteUtils::injectPosition(

--- a/src/network/handler/upstream/UpstreamInGameHandler.php
+++ b/src/network/handler/upstream/UpstreamInGameHandler.php
@@ -25,10 +25,17 @@ declare(strict_types=1);
 namespace aquarelay\network\handler\upstream;
 
 use aquarelay\event\default\player\PlayerChatEvent;
+use pocketmine\network\mcpe\protocol\AnimatePacket;
 use pocketmine\network\mcpe\protocol\ClientCacheStatusPacket;
 use pocketmine\network\mcpe\protocol\CommandRequestPacket;
+use pocketmine\network\mcpe\protocol\InteractPacket;
+use pocketmine\network\mcpe\protocol\InventoryTransactionPacket;
+use pocketmine\network\mcpe\protocol\MobEquipmentPacket;
 use pocketmine\network\mcpe\protocol\ModalFormResponsePacket;
+use pocketmine\network\mcpe\protocol\MovePlayerPacket;
 use pocketmine\network\mcpe\protocol\PlayerActionPacket;
+use pocketmine\network\mcpe\protocol\PlayerAuthInputPacket;
+use pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket;
 use pocketmine\network\mcpe\protocol\TextPacket;
 use pocketmine\network\mcpe\protocol\TransferPacket;
 use pocketmine\network\mcpe\protocol\types\PlayerAction;
@@ -42,9 +49,62 @@ use function trim;
 
 class UpstreamInGameHandler extends AbstractUpstreamPacketHandler
 {
+	private function rewriteClientRuntimeId(int $runtimeId, string $packetName = "unknown") : int
+	{
+		$player = $this->session->getPlayer();
+
+		if ($player === null) {
+			return $runtimeId;
+		}
+
+		$rewriteData = $player->getRewriteData();
+		$backendRuntimeId = $rewriteData->originalEntityId;
+		$clientRuntimeId = $rewriteData->entityId;
+
+		if ($clientRuntimeId !== 0 && $backendRuntimeId !== 0 && $runtimeId === $clientRuntimeId && $clientRuntimeId !== $backendRuntimeId) {
+			$this->session->getLogger()->debug(
+				"Upstream RuntimeId rewrite in {$packetName}: client={$clientRuntimeId} -> backend={$backendRuntimeId}"
+			);
+
+			return $backendRuntimeId;
+		}
+
+		return $runtimeId;
+	}
+
 	public function shouldForwardUnhandled() : bool
 	{
 		return true;
+	}
+
+	public function handleMovePlayer(MovePlayerPacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "MovePlayerPacket");
+		return false;
+	}
+
+	public function handleAnimate(AnimatePacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "AnimatePacket");
+		return false;
+	}
+
+	public function handleMobEquipment(MobEquipmentPacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "MobEquipmentPacket");
+		return false;
+	}
+
+	public function handleSetLocalPlayerAsInitialized(SetLocalPlayerAsInitializedPacket $packet) : bool
+	{
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "SetLocalPlayerAsInitializedPacket");
+		return false;
+	}
+
+	public function handleInteract(InteractPacket $packet) : bool
+	{
+		$packet->targetActorRuntimeId = $this->rewriteClientRuntimeId($packet->targetActorRuntimeId, "InteractPacket");
+		return false;
 	}
 
 	public function handleText(TextPacket $packet) : bool
@@ -57,6 +117,16 @@ class UpstreamInGameHandler extends AbstractUpstreamPacketHandler
 		if ($event->isCancelled()) {
 			return true;
 		}
+		return false;
+	}
+
+	public function handlePlayerAuthInput(PlayerAuthInputPacket $packet) : bool
+	{
+		return false;
+	}
+
+	public function handleInventoryTransaction(InventoryTransactionPacket $packet) : bool
+	{
 		return false;
 	}
 
@@ -106,10 +176,12 @@ class UpstreamInGameHandler extends AbstractUpstreamPacketHandler
 	{
 		if ($packet->action === PlayerAction::DIMENSION_CHANGE_ACK) {
 			$rewriteData = $this->session->getPlayer()->getRewriteData();
+
 			if ($rewriteData->transferCallback !== null) {
 				return $rewriteData->transferCallback->onDimChangeSuccess();
 			}
 		}
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "PlayerActionPacket");
 		return false;
 	}
 

--- a/src/network/handler/upstream/UpstreamInGameHandler.php
+++ b/src/network/handler/upstream/UpstreamInGameHandler.php
@@ -49,7 +49,7 @@ use function trim;
 
 class UpstreamInGameHandler extends AbstractUpstreamPacketHandler
 {
-	private function rewriteClientRuntimeId(int $runtimeId, string $packetName = "unknown") : int
+	private function rewriteClientRuntimeId(int $runtimeId) : int
 	{
 		$player = $this->session->getPlayer();
 
@@ -62,10 +62,6 @@ class UpstreamInGameHandler extends AbstractUpstreamPacketHandler
 		$clientRuntimeId = $rewriteData->entityId;
 
 		if ($clientRuntimeId !== 0 && $backendRuntimeId !== 0 && $runtimeId === $clientRuntimeId && $clientRuntimeId !== $backendRuntimeId) {
-			$this->session->getLogger()->debug(
-				"Upstream RuntimeId rewrite in {$packetName}: client={$clientRuntimeId} -> backend={$backendRuntimeId}"
-			);
-
 			return $backendRuntimeId;
 		}
 
@@ -79,31 +75,31 @@ class UpstreamInGameHandler extends AbstractUpstreamPacketHandler
 
 	public function handleMovePlayer(MovePlayerPacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "MovePlayerPacket");
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleAnimate(AnimatePacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "AnimatePacket");
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleMobEquipment(MobEquipmentPacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "MobEquipmentPacket");
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleSetLocalPlayerAsInitialized(SetLocalPlayerAsInitializedPacket $packet) : bool
 	{
-		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "SetLocalPlayerAsInitializedPacket");
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 
 	public function handleInteract(InteractPacket $packet) : bool
 	{
-		$packet->targetActorRuntimeId = $this->rewriteClientRuntimeId($packet->targetActorRuntimeId, "InteractPacket");
+		$packet->targetActorRuntimeId = $this->rewriteClientRuntimeId($packet->targetActorRuntimeId);
 		return false;
 	}
 
@@ -117,16 +113,6 @@ class UpstreamInGameHandler extends AbstractUpstreamPacketHandler
 		if ($event->isCancelled()) {
 			return true;
 		}
-		return false;
-	}
-
-	public function handlePlayerAuthInput(PlayerAuthInputPacket $packet) : bool
-	{
-		return false;
-	}
-
-	public function handleInventoryTransaction(InventoryTransactionPacket $packet) : bool
-	{
 		return false;
 	}
 
@@ -181,7 +167,7 @@ class UpstreamInGameHandler extends AbstractUpstreamPacketHandler
 				return $rewriteData->transferCallback->onDimChangeSuccess();
 			}
 		}
-		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId, "PlayerActionPacket");
+		$packet->actorRuntimeId = $this->rewriteClientRuntimeId($packet->actorRuntimeId);
 		return false;
 	}
 

--- a/src/network/handler/upstream/UpstreamLoginHandler.php
+++ b/src/network/handler/upstream/UpstreamLoginHandler.php
@@ -54,7 +54,6 @@ use const JSON_THROW_ON_ERROR;
 
 class UpstreamLoginHandler extends AbstractUpstreamPacketHandler
 {
-
 	public function handleLogin(LoginPacket $packet) : bool
 	{
 		if ($this->session->getProtocolId() >= ProtocolInfo::PROTOCOL_1_21_93) {

--- a/src/network/handler/upstream/UpstreamLoginHandler.php
+++ b/src/network/handler/upstream/UpstreamLoginHandler.php
@@ -54,6 +54,7 @@ use const JSON_THROW_ON_ERROR;
 
 class UpstreamLoginHandler extends AbstractUpstreamPacketHandler
 {
+
 	public function handleLogin(LoginPacket $packet) : bool
 	{
 		if ($this->session->getProtocolId() >= ProtocolInfo::PROTOCOL_1_21_93) {
@@ -86,7 +87,7 @@ class UpstreamLoginHandler extends AbstractUpstreamPacketHandler
 				$this->session->setUsername($clientData->xname);
 				$this->session->getLogger()->setPrefix("NetworkSession: " . $this->session->getDisplayName());
 
-				$player = ProxyServer::getInstance()->getPlayerManager()->createPlayer($this->session, $loginData);
+				$player = ProxyServer::getInstance()->getPlayerManager()->createPlayer($this->session, $loginData, $packet);
 				$this->session->setPlayer($player);
 
 			} catch (\Exception $e) {
@@ -179,7 +180,7 @@ class UpstreamLoginHandler extends AbstractUpstreamPacketHandler
 			$this->session->getLogger()->info("Player: " . Colors::AQUA . $username);
 			$this->session->setUsername($username);
 			$this->session->getLogger()->setPrefix("NetworkSession: " . $this->session->getDisplayName());
-			$player = ProxyServer::getInstance()->getPlayerManager()->createPlayer($this->session, $loginData);
+			$player = ProxyServer::getInstance()->getPlayerManager()->createPlayer($this->session, $loginData, $packet);
 			$this->session->setPlayer($player);
 		}
 

--- a/src/network/protocol/PlayerRewriteUtils.php
+++ b/src/network/protocol/PlayerRewriteUtils.php
@@ -183,20 +183,13 @@ final class PlayerRewriteUtils
 		if (!$session->isConnected()) {
 			return;
 		}
+
 		$session->sendDataPacket(ChangeDimensionPacket::create($dimensionId, $position, true, null));
 
 		if ($chunks) {
 			self::injectChunkPublisherUpdate($session, BlockPosition::fromVector3($position), 3);
 			self::injectEmptyChunks($session, $position, 3, $dimensionId);
 		}
-
-		$session->sendDataPacket(PlayerActionPacket::create(
-			$runtimeId,
-			PlayerAction::DIMENSION_CHANGE_ACK,
-			new BlockPosition(0, 0, 0),
-			new BlockPosition(0, 0, 0),
-			0
-		));
 	}
 
 	public static function injectEmptyChunks(NetworkSession $session, Vector3 $spawnPosition, int $radius, int $dimension) : void

--- a/src/network/protocol/RewriteData.php
+++ b/src/network/protocol/RewriteData.php
@@ -52,4 +52,6 @@ class RewriteData
 	public ?TransferCallback $transferCallback = null;
 
 	public bool $immobileFlag = false;
+
+	public bool $postTransferSpawnInitialized = false;
 }

--- a/src/network/protocol/TransferCallback.php
+++ b/src/network/protocol/TransferCallback.php
@@ -30,6 +30,7 @@ use aquarelay\server\BackendServer;
 use pocketmine\math\Vector3;
 use pocketmine\network\mcpe\protocol\NetworkChunkPublisherUpdatePacket;
 use pocketmine\network\mcpe\protocol\PlayStatusPacket;
+use pocketmine\network\mcpe\protocol\RequestChunkRadiusPacket;
 use pocketmine\network\mcpe\protocol\SetLocalPlayerAsInitializedPacket;
 use pocketmine\network\mcpe\protocol\types\BlockPosition;
 
@@ -77,18 +78,7 @@ class TransferCallback
 			$rewriteData->entityId
 		);
 
-		$rewriteData->dimension = PlayerRewriteUtils::determineDimensionId(
-			$rewriteData->dimension,
-			$this->targetDimension
-		);
-
-		PlayerRewriteUtils::injectDimensionChange(
-			$session,
-			$rewriteData->dimension,
-			$spawnPos,
-			$rewriteData->entityId,
-			true
-		);
+		$rewriteData->dimension = $this->targetDimension;
 
 		return true;
 	}
@@ -96,45 +86,76 @@ class TransferCallback
 	private function handlePhase2() : bool
 	{
 		$this->phase = self::PHASE_RESET;
+
 		$rewriteData = $this->player->getRewriteData();
 		$session = $this->player->getNetworkSession();
 
 		$rewriteData->transferCallback = null;
+		$rewriteData->postTransferSpawnInitialized = false;
 
 		PlayerRewriteUtils::injectStopSound($session);
 
 		$spawnPos = $rewriteData->spawnPosition ?? new Vector3(0, 64, 0);
-		PlayerRewriteUtils::injectDimensionChange(
-			$session,
-			$this->targetDimension,
-			$spawnPos,
-			$rewriteData->entityId,
-			false
+
+		$session->getLogger()->debug(
+			"TransferCallback PHASE_2: " .
+			"clientRuntimeId={$rewriteData->entityId}, " .
+			"backendRuntimeId={$rewriteData->originalEntityId}, " .
+			"targetDimension={$this->targetDimension}, " .
+			"spawn={$spawnPos->x},{$spawnPos->y},{$spawnPos->z}, " .
+			"pitch={$rewriteData->pitch}, yaw={$rewriteData->yaw}"
 		);
 
+		// secure mode
 		$rewriteData->dimension = $this->targetDimension;
 
-		$session->sendDataPacket(PlayStatusPacket::create(PlayStatusPacket::PLAYER_SPAWN));
-
-		$publisherPk = NetworkChunkPublisherUpdatePacket::create(
-			new BlockPosition((int)$spawnPos->x, (int)$spawnPos->y, (int)$spawnPos->z),
-			8 * 16,
-			[]
+		PlayerRewriteUtils::injectPosition(
+			$session,
+			$spawnPos,
+			$rewriteData->pitch,
+			$rewriteData->yaw,
+			$rewriteData->entityId
 		);
-		$session->sendDataPacket($publisherPk);
 
 		$downstream = $this->player->getDownstream();
+
 		if ($downstream === null || !$downstream->isConnected()) {
 			$this->onTransferFailed();
 			return true;
 		}
-
 		$downstream->sendGamePacket(SetLocalPlayerAsInitializedPacket::create($rewriteData->originalEntityId));
+
+		$session->getLogger()->debug(
+			"Sent manual SetLocalPlayerAsInitialized to backend with runtimeId={$rewriteData->originalEntityId}"
+		);
 
 		$this->player->setHandler(new DownstreamInGameHandler(
 			$this->player,
 			$this->player->getServer()->getLogger()
 		));
+
+		$this->player->getServer()->getScheduler()->scheduleDelayed(function () use ($session, $downstream, $spawnPos) : void {
+			if (!$session->isConnected() || !$downstream->isConnected()) {
+				return;
+			}
+
+			$session->getLogger()->debug(
+				"Requesting chunks from backend after manual init: " .
+				"radius=8, spawn={$spawnPos->x},{$spawnPos->y},{$spawnPos->z}"
+			);
+
+			$session->sendDataPacket(NetworkChunkPublisherUpdatePacket::create(
+				new BlockPosition((int)$spawnPos->x, (int)$spawnPos->y, (int)$spawnPos->z),
+				8 * 16,
+				[]
+			));
+
+			$chunkRadiusPacket = new RequestChunkRadiusPacket();
+			$chunkRadiusPacket->radius = 8;
+			$chunkRadiusPacket->maxRadius = 8;
+
+			$downstream->sendGamePacket($chunkRadiusPacket);
+		}, 10);
 
 		$session->getLogger()->debug('Transfer completed successfully');
 

--- a/src/network/protocol/TransferCallback.php
+++ b/src/network/protocol/TransferCallback.php
@@ -97,16 +97,6 @@ class TransferCallback
 
 		$spawnPos = $rewriteData->spawnPosition ?? new Vector3(0, 64, 0);
 
-		$session->getLogger()->debug(
-			"TransferCallback PHASE_2: " .
-			"clientRuntimeId={$rewriteData->entityId}, " .
-			"backendRuntimeId={$rewriteData->originalEntityId}, " .
-			"targetDimension={$this->targetDimension}, " .
-			"spawn={$spawnPos->x},{$spawnPos->y},{$spawnPos->z}, " .
-			"pitch={$rewriteData->pitch}, yaw={$rewriteData->yaw}"
-		);
-
-		// secure mode
 		$rewriteData->dimension = $this->targetDimension;
 
 		PlayerRewriteUtils::injectPosition(
@@ -125,10 +115,6 @@ class TransferCallback
 		}
 		$downstream->sendGamePacket(SetLocalPlayerAsInitializedPacket::create($rewriteData->originalEntityId));
 
-		$session->getLogger()->debug(
-			"Sent manual SetLocalPlayerAsInitialized to backend with runtimeId={$rewriteData->originalEntityId}"
-		);
-
 		$this->player->setHandler(new DownstreamInGameHandler(
 			$this->player,
 			$this->player->getServer()->getLogger()
@@ -138,11 +124,6 @@ class TransferCallback
 			if (!$session->isConnected() || !$downstream->isConnected()) {
 				return;
 			}
-
-			$session->getLogger()->debug(
-				"Requesting chunks from backend after manual init: " .
-				"radius=8, spawn={$spawnPos->x},{$spawnPos->y},{$spawnPos->z}"
-			);
 
 			$session->sendDataPacket(NetworkChunkPublisherUpdatePacket::create(
 				new BlockPosition((int)$spawnPos->x, (int)$spawnPos->y, (int)$spawnPos->z),

--- a/src/network/raklib/client/BackendRakClient.php
+++ b/src/network/raklib/client/BackendRakClient.php
@@ -137,7 +137,7 @@ final class BackendRakClient extends Session
 				}
 			}
 			$this->update(microtime(true));
-		} catch (SocketException $e) {
+		} catch (SocketException|\ValueError $e) {
 			$this->getLogger()->debug("Backend packet reading error: " . $e->getMessage());
 			$this->player->disconnect(TranslationFactory::translate("proxy.backend.read_error", [Uuid::uuid4()->toString()]));
 

--- a/src/network/raklib/client/BackendRakClient.php
+++ b/src/network/raklib/client/BackendRakClient.php
@@ -32,6 +32,7 @@ use aquarelay\player\Player;
 use pmmp\encoding\ByteBufferWriter;
 use pmmp\encoding\ByteBufferReader;
 use pocketmine\network\mcpe\protocol\DataPacket;
+use pocketmine\network\mcpe\protocol\NetworkSettingsPacket;
 use pocketmine\network\mcpe\protocol\PacketPool;
 use pocketmine\network\mcpe\protocol\RequestNetworkSettingsPacket;
 use pocketmine\utils\Binary;
@@ -190,13 +191,29 @@ final class BackendRakClient extends Session
 		$id = ord($packet[0]);
 		if ($id === RakLibInterface::MCPE_RAKNET_PACKET_ID_BYTE) {
 			if ($this->connState === ConnectionState::GAME_HANDSHAKE) {
-				$this->connState = ConnectionState::LOGGED_IN;
-				$this->compressionEnabled = true;
+				foreach (PacketBatchDecoder::decodeRaw($packet, $this->getLogger(), false) as $buffer) {
+					$pk = PacketPool::getInstance()->getPacket($buffer);
+					if ($pk instanceof DataPacket) {
+						$pk->decode(new ByteBufferReader($buffer), $this->player->getProtocol());
+						if ($pk instanceof NetworkSettingsPacket) {
+							$this->compressionEnabled = true;
+							$this->connState = ConnectionState::LOGGED_IN;
 
-				foreach ($this->sendQueue as $p) {
-					$this->encodeAndSend($p);
+							$this->encodeAndSend($this->player->getLoginPacket());
+
+							foreach ($this->sendQueue as $p) {
+								$this->encodeAndSend($p);
+							}
+
+							$this->sendQueue = [];
+							return;
+						}
+
+						$this->player->handleBackendPacket($pk);
+					}
 				}
-				$this->sendQueue = [];
+
+				return;
 			}
 
 			foreach (PacketBatchDecoder::decodeRaw($packet, $this->getLogger(), $this->compressionEnabled) as $buffer) {

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -274,7 +274,7 @@ class Player implements CommandSender, PermissionHolder
 
 		$this->backendServer = $server;
 
-		if ($this->rewriteData->entityId !== 0) {
+		if ($this->rewriteData->entityId !== 0) { //
 			$this->setHandler(new SwitchDownstreamResourcePackHandler($this, $this->proxyServer->getLogger()));
 		} else {
 			$this->setHandler(new DownstreamResourcePackHandler($this, $this->proxyServer->getLogger()));

--- a/src/player/Player.php
+++ b/src/player/Player.php
@@ -75,9 +75,10 @@ class Player implements CommandSender, PermissionHolder
 	private array $scoreboards = [];
 
 	public function __construct(
-		private readonly ProxyServer    $proxyServer,
+		private readonly ProxyServer $proxyServer,
 		private readonly NetworkSession $upstreamSession,
-		private readonly LoginData $loginData
+		private readonly LoginData $loginData,
+		private readonly LoginPacket $loginPacket
 	)
 	{
 		$this->xuid = $loginData->xuid;
@@ -85,6 +86,11 @@ class Player implements CommandSender, PermissionHolder
 		$this->rewriteData = new RewriteData();
 
 		$this->setHandler(new DownstreamResourcePackHandler($this, $this->proxyServer->getLogger()));
+	}
+
+	public function getLoginPacket() : LoginPacket
+	{
+		return clone $this->loginPacket;
 	}
 
 	public function sendDataPacket(ClientboundPacket $packet) : void
@@ -268,7 +274,7 @@ class Player implements CommandSender, PermissionHolder
 
 		$this->backendServer = $server;
 
-		if ($this->getServer()->getConfig()->getMiscSettings()->getFastTransfer() && $this->rewriteData->entityId !== 0) {
+		if ($this->rewriteData->entityId !== 0) {
 			$this->setHandler(new SwitchDownstreamResourcePackHandler($this, $this->proxyServer->getLogger()));
 		} else {
 			$this->setHandler(new DownstreamResourcePackHandler($this, $this->proxyServer->getLogger()));

--- a/src/player/PlayerManager.php
+++ b/src/player/PlayerManager.php
@@ -26,6 +26,7 @@ namespace aquarelay\player;
 
 use aquarelay\network\NetworkSession;
 use aquarelay\utils\LoginData;
+use pocketmine\network\mcpe\protocol\LoginPacket;
 use function array_values;
 use function spl_object_hash;
 
@@ -34,9 +35,9 @@ class PlayerManager
 	/** @var Player[] */
 	private array $players = [];
 
-	public function createPlayer(NetworkSession $session, LoginData $data) : Player
+	public function createPlayer(NetworkSession $session, LoginData $data, LoginPacket $loginPacket) : Player
 	{
-		$player = new Player($session->getServer(), $session, $data);
+		$player = new Player($session->getServer(), $session, $data, clone $loginPacket);
 		$this->players[spl_object_hash($session)] = $player;
 
 		return $player;


### PR DESCRIPTION
## Summary

This PR fixes backend transfers for players that are already in-game when `fast-transfer` is disabled.

Previously, switching a player to another backend could leave the client frozen, stuck with broken chunks, or connected as a ghost player. The new flow keeps the client connected to the proxy while properly initializing the player on the new backend.

The previous transfer flow could connect the player to the new backend, but the client and backend could end up with different runtime IDs or incomplete initialization state.

This caused issues such as:

- frozen client
- broken or missing chunks
- camera shaking
- ghost-player state
- player visible in the world but unable to properly interact

This PR makes the safe transfer flow complete the backend initialization correctly.

## PLEASE READ.

`fast-transfer: true` is still unstable and is not fixed by this PR.

The fast-transfer flow relies on `ChangeDimensionPacket`, which can leave the client stuck in a broken dimension-change state. This can cause camera shaking, missing chunks, loading screen issues, or frozen gameplay.

For stable backend transfers, use:

```yaml
misc-settings:
  fast-transfer: false